### PR TITLE
Add dependency on libjpeg to nxextract

### DIFF
--- a/contrib/applications/NXextract/src/CMakeLists.txt
+++ b/contrib/applications/NXextract/src/CMakeLists.txt
@@ -24,6 +24,8 @@
 #
 #=============================================================================
 
+find_package(JPEG REQUIRED)
+
 set(SOURCE extractorapp.cpp 
            extractor.cpp 
            templateparsor.cpp
@@ -49,5 +51,5 @@ set(SOURCE extractorapp.cpp
            variant.cpp)
 
 add_executable(nxextract ${SOURCE})
-target_link_libraries(nxextract NeXus_Shared_Library)
+target_link_libraries(nxextract NeXus_Shared_Library jpeg)
 


### PR DESCRIPTION
Previously nxextract could only be compiled when HDF4 support was
enabled, as HDF4 linked JPEG into the NeXus library.