### PR TITLE
Warn when using deprecated NAPI functions

### DIFF
--- a/bindings/cpp/NeXusFile.hpp
+++ b/bindings/cpp/NeXusFile.hpp
@@ -129,7 +129,7 @@ namespace NeXus {
      * This is a deprecated function.
      * \param com The compression type.
      */
-    void compress(NXcompression comp);
+    void compress(NXcompression comp) NEXUS_DEPRECATED_FUNCTION;
 
     /**
      * Initialize the pending group search to start again.

--- a/include/napi.h
+++ b/include/napi.h
@@ -270,6 +270,12 @@ typedef struct {
  * 
  */
 
+#ifdef __GNUC__
+#define NEXUS_DEPRECATED_FUNCTION __attribute__((deprecated))
+#else
+#define NEXUS_DEPRECATED_FUNCTION
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -441,7 +447,7 @@ extern  NXstatus NXcompmakedata64 (NXhandle handle, CONSTCHAR* label, int dataty
    * \li NX_COMP_HUF Huffmann encoding (only HDF-4)
    * \ingroup c_readwrite
    */
-extern  NXstatus  NXcompress (NXhandle handle, int compr_type);
+extern  NXstatus  NXcompress (NXhandle handle, int compr_type) NEXUS_DEPRECATED_FUNCTION;
 
   /**
    * Open access to a dataset. After this call it is possible to write and read data or 
@@ -638,7 +644,7 @@ extern  NXstatus  NXgetslab64(NXhandle handle, void* data, const int64_t start[]
    * \return NX_OK on success, NX_ERROR in the case of an error, NX_EOD when there are no more items.   
    * \ingroup c_readwrite
    */
-extern  NXstatus  NXgetnextattr(NXhandle handle, NXname pName, int *iLength, int *iType);
+extern  NXstatus  NXgetnextattr(NXhandle handle, NXname pName, int *iLength, int *iType) NEXUS_DEPRECATED_FUNCTION;
 
   /**
    * Read an attribute containing a single string or numerical value.

--- a/include/napi.h
+++ b/include/napi.h
@@ -270,7 +270,7 @@ typedef struct {
  * 
  */
 
-#ifdef __GNUC__
+#if (defined(__GNUC__) || defined(__clang__))
 #define NEXUS_DEPRECATED_FUNCTION __attribute__((deprecated))
 #else
 #define NEXUS_DEPRECATED_FUNCTION


### PR DESCRIPTION
Using GCC's __attribute__((deprecated))

Use #ifdef __GNUC__ so that building on other compilers doesn't get broken