### PR TITLE
Hide deprecated HDF5 API

### DIFF
--- a/include/napi5.h
+++ b/include/napi5.h
@@ -3,6 +3,10 @@
 
 #define NX5SIGNATURE 959695
 
+/* Hide deprecated API from HDF5 versions before 1.8
+ * Required to build on Ubuntu 12.04 */
+#define H5_NO_DEPRECATED_SYMBOLS
+
 #include <hdf5.h>
 
 /* HDF5 interface */


### PR DESCRIPTION
On Ubuntu 12.04, despite the HDF5 version being 1.8.x, the default
HDF5 API is the 'compatibility' API from HDF5 v1.6.x.
Declaring H5_NO_DEPRECATED_SYMBOLS fixes this.