### PR TITLE
Make NXtranslate compatible with CMake 2.8.7

### DIFF
--- a/applications/NXtranslate/CMakeLists.txt
+++ b/applications/NXtranslate/CMakeLists.txt
@@ -47,46 +47,41 @@ add_definitions(-DFRM2_RETRIEVER
                 -DSPEC_RETRIEVER)
 
 
-include_directories(. ${LIBXML2_INCLUDE_DIR} text_collist text_plain 
-                    text_xml sns_histogram FRM2 loopy)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/text_collist"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/text_plain" 
+                    "${CMAKE_CURRENT_SOURCE_DIR}/text_xml"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/sns_histogram"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/FRM2"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/loopy"
+                    ${LIBXML2_INCLUDE_DIR})
 
 set(SOURCES attr.cpp 
             main.cpp 
             nexus_retriever.cpp  
             nexus_util.cpp 
             node.cpp
-	        node_util.cpp 
+            node_util.cpp 
             retriever.cpp 
             string_util.cpp 
             xml_parser.cpp
-            xml_util.h 
-            xml_util.cpp 
-            attr.h 
-            nexus_retriever.h 
-            nexus_util.h node.h 
-            node_util.h 
-            nxtranslate_debug.h 
-            Ptr.h 
-            retriever.h 
-            string_util.h 
-            xml_parser.h 
-            tree.hh 
-            dynamic_retriever.cpp 
-            dynamic_retriever.h)
+            xml_util.cpp
+            dynamic_retriever.cpp)
 
-add_executable(nxtranslate ${SOURCES} 
-               $<TARGET_OBJECTS:BinaryRetriever>
-               $<TARGET_OBJECTS:TextCollist>
-               $<TARGET_OBJECTS:TextPlain>
-               $<TARGET_OBJECTS:TextXML>
-               $<TARGET_OBJECTS:SNShistogram>
-               $<TARGET_OBJECTS:FRM2>
-               $<TARGET_OBJECTS:Loopy>
-               $<TARGET_OBJECTS:Spec>
-               $<TARGET_OBJECTS:Edf>
-              )
+add_executable(nxtranslate ${SOURCES})
 
-target_link_libraries(nxtranslate NeXus_Static_Library ${LIBXML2_LIBRARIES})
+target_link_libraries(nxtranslate
+                      NeXus_Static_Library
+                      BinaryRetriever
+                      TextCollist
+                      TextPlain
+                      TextXML
+                      SNShistogram
+                      FRM2
+                      Loopy
+                      Spec
+                      Edf
+                      ${LIBXML2_LIBRARIES})
 
 
 install (TARGETS nxtranslate DESTINATION bin COMPONENT Runtime)

--- a/applications/NXtranslate/FRM2/CMakeLists.txt
+++ b/applications/NXtranslate/FRM2/CMakeLists.txt
@@ -26,7 +26,7 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library (FRM2 OBJECT frm2_retriever.cpp frm2_retriever.h)
+add_library (FRM2 frm2_retriever.cpp)
 

--- a/applications/NXtranslate/binary/CMakeLists.txt
+++ b/applications/NXtranslate/binary/CMakeLists.txt
@@ -26,6 +26,6 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/..")
 
-add_library (BinaryRetriever OBJECT BinaryRetriever.cpp BinaryRetriever.hpp)
+add_library (BinaryRetriever BinaryRetriever.cpp)

--- a/applications/NXtranslate/esrf_edf/CMakeLists.txt
+++ b/applications/NXtranslate/esrf_edf/CMakeLists.txt
@@ -26,8 +26,7 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library (Edf OBJECT edf_reader.cpp edf_reader.h edf_retriever.cpp 
-                        edf_retriever.h)
+add_library (Edf edf_reader.cpp edf_retriever.cpp)
 

--- a/applications/NXtranslate/loopy/CMakeLists.txt
+++ b/applications/NXtranslate/loopy/CMakeLists.txt
@@ -26,7 +26,7 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library (Loopy OBJECT retriever.cpp retriever.h)
+add_library (Loopy retriever.cpp)
 

--- a/applications/NXtranslate/sns_histogram/CMakeLists.txt
+++ b/applications/NXtranslate/sns_histogram/CMakeLists.txt
@@ -26,10 +26,8 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library (SNShistogram OBJECT string_location_format.cpp 
-                                 string_location_format.h
-                                 SNS_retriever.cpp SNS_retriever.hpp 
-                                 retriever.hpp)
+add_library (SNShistogram string_location_format.cpp 
+                          SNS_retriever.cpp)
 

--- a/applications/NXtranslate/spec/CMakeLists.txt
+++ b/applications/NXtranslate/spec/CMakeLists.txt
@@ -26,9 +26,8 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library (Spec OBJECT SPEClib.cpp SPEClib.h spec_retriever.cpp  
-                         spec_retriever.h)
+add_library (Spec SPEClib.cpp spec_retriever.cpp)
 
 

--- a/applications/NXtranslate/text_collist/CMakeLists.txt
+++ b/applications/NXtranslate/text_collist/CMakeLists.txt
@@ -26,8 +26,8 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library(TextCollist OBJECT collist_retriever.cpp collist_retriever.h)
+add_library(TextCollist collist_retriever.cpp)
 
 

--- a/applications/NXtranslate/text_plain/CMakeLists.txt
+++ b/applications/NXtranslate/text_plain/CMakeLists.txt
@@ -26,7 +26,7 @@
 #
 #=============================================================================
 
-include_directories(. ../)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library (TextPlain OBJECT retriever.cpp retriever.h)
+add_library (TextPlain retriever.cpp)
 

--- a/applications/NXtranslate/text_xml/CMakeLists.txt
+++ b/applications/NXtranslate/text_xml/CMakeLists.txt
@@ -26,9 +26,9 @@
 #
 #=============================================================================
 
-include_directories(. ../ ${LIBXML2_INCLUDE_DIR})
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}" ${LIBXML2_INCLUDE_DIR})
 
-add_library (TextXML OBJECT xml_retriever.cpp retriever.h
-                            xml_retriever_dom.cpp xml_retriever_dom.h
-                            void_copy.cpp void_copy.h)
+add_library (TextXML xml_retriever.cpp
+                     xml_retriever_dom.cpp
+                     void_copy.cpp)
 


### PR DESCRIPTION
When trying to build the apps with CMake 2.8.7 there were lots of
errors due to NXtranslate trying to use unsupported features.