### PR TITLE
Fix segfault on Ubuntu 12.04

### DIFF
--- a/src/napi5.c
+++ b/src/napi5.c
@@ -23,6 +23,8 @@
 
 ----------------------------------------------------------------------------*/
 
+#define H5Aiterate_vers 2
+
 #include <nxconfig.h>
 
 #ifdef WITH_HDF5


### PR DESCRIPTION
For some reason the fix in "HIDE deprecated HDF5 API"
(commit 5ebd9f52b39c2c5156b4b9363c14928fb4ad3737)
does not completely change the API used, leading to a segfault
when running the tests. This fixes the segfault.