### PR TITLE
Improved `buff2str` function

### DIFF
--- a/applications/nxingest/nxingest_nexus.h
+++ b/applications/nxingest/nxingest_nexus.h
@@ -61,9 +61,6 @@ class NxClass
 		bool isOK(){ if(status == NXING_OK) return true; else return false; }
 		bool isNotOK(){ if(status != NXING_OK) return true; else return false; }
 
-	private:
-		char* buff2str(void* buff, int rank, int dim[], int data_type, char* vector, char* value);
-
 };
 
 #endif


### PR DESCRIPTION
Fixes #377

* Made type casts more portable

* Replaced incorrect sprintf format strings with C++ stringstream

* Fixed memory leak

* Changed interface to avoid overflow vulnerability

The functions which call buff2str are almost as bad themselves,
and also need to be refactored...