### PR TITLE
Use shared library link

### DIFF
--- a/applications/NXtranslate/CMakeLists.txt
+++ b/applications/NXtranslate/CMakeLists.txt
@@ -71,7 +71,7 @@ set(SOURCES attr.cpp
 add_executable(nxtranslate ${SOURCES})
 
 target_link_libraries(nxtranslate
-                      NeXus_Static_Library
+                      NeXus_Shared_Library
                       BinaryRetriever
                       TextCollist
                       TextPlain


### PR DESCRIPTION
A static link is probably best ultimately, but the other applications
seem to be shared and static linking currently gives an HDF4 link error

fix for #400 