### PR TITLE
Fix warnings generated by Xcode 7.2

### DIFF
--- a/src/napi.c
+++ b/src/napi.c
@@ -2015,7 +2015,7 @@ char *NXIformatNeXusTime()
 			time_info->tm_hour,
 			time_info->tm_min,
 			time_info->tm_sec,
-			abs(gmt_offset / 3600), abs((gmt_offset % 3600) / 60)
+			labs(gmt_offset / 3600), labs((gmt_offset % 3600) / 60)
 		    );
 	} else {
 		strcpy(time_buffer, "1970-01-01T00:00:00+00:00");

--- a/src/napi5.c
+++ b/src/napi5.c
@@ -1819,10 +1819,6 @@ NXstatus NX5getdata(NXhandle fid, void *data)
 	}
 	ndims = H5Sget_simple_extent_dims(pFile->iCurrentS, dims, NULL);
 
-	if (ndims < 0) {
-		NXReportError("ERROR: unable to read dims");
-		return NX_ERROR;
-	}
 	if (ndims == 0) {	/* SCALAR dataset */
 		hid_t datatype = H5Dget_type(pFile->iCurrentD);
 		hid_t filespace = H5Dget_space(pFile->iCurrentD);
@@ -2500,11 +2496,6 @@ NXstatus  NX5getattra(NXhandle handle, char* name, void* data)
 	datatype = H5Aget_type(pFile->iCurrentA);
 	ndims = H5Sget_simple_extent_dims(filespace, dims, NULL);
 
-	if (ndims < 0) {
-		NXReportError("ERROR: unable to read dims");
-		return NX_ERROR;
-	}
-
 	is_vlen_str = H5Tis_variable_str(datatype);
 	if (ndims == 0 && is_vlen_str) {
 		/* this assumes a fixed size - is this dangerous? */
@@ -2584,10 +2575,6 @@ NXstatus  NX5getattrainfo(NXhandle handle, NXname name, int *rank, int dim[], in
 
 	filespace = H5Aget_space(pFile->iCurrentA);
 	myrank = H5Sget_simple_extent_ndims(filespace);
-	if (myrank < 0) {
-		NXReportError("ERROR: Cannot determine attribute rank");
-		return NX_ERROR;
-	}
 	iRet = H5Sget_simple_extent_dims(filespace, myDim, NULL);
 	if (iRet < 0) {
 		NXReportError("ERROR: Cannot determine attribute dimensions");


### PR DESCRIPTION
in napi.c 
```
[14/25] Building C object src/CMakeFiles/NeXus_Static_Library.dir/napi.c.o
src/napi.c:2018:4: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                        abs(gmt_offset / 3600), abs((gmt_offset % 3600) / 60)
                        ^
/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                                                       ^
src/napi.c:2018:4: note: use function 'labs' instead
                        abs(gmt_offset / 3600), abs((gmt_offset % 3600) / 60)
                        ^~~
                        labs
/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                                                       ^
src/napi.c:2018:28: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                        abs(gmt_offset / 3600), abs((gmt_offset % 3600) / 60)
                                                ^
/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                                                       ^
src/napi.c:2018:28: note: use function 'labs' instead
                        abs(gmt_offset / 3600), abs((gmt_offset % 3600) / 60)
                                                ^~~
                                                labs
/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                                                       ^
2 warnings generated.
```
This can be fixed by using `labs` instead of `abs`.

in napi5.c

```
[15/25] Building C object src/CMakeFiles/NeXus_Static_Library.dir/napi5.c.o
src/napi5.c:1822:12: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
        if (ndims < 0) {
            ~~~~~ ^ ~
src/napi5.c:2503:12: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
        if (ndims < 0) {
            ~~~~~ ^ ~
src/napi5.c:2587:13: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
        if (myrank < 0) {
            ~~~~~~ ^ ~
3 warnings generated.
```
In the `H5public.h` header included with HDF5 one can confirm that `hsize_t` is type `unsigned long long` which cannot be < 0.
