### PR TITLE
Update napi interface to accept a C++ string literal.

### DIFF
--- a/include/napi.h
+++ b/include/napi.h
@@ -645,7 +645,7 @@ extern  NXstatus  NXgetnextattr(NXhandle handle, NXname pName, int *iLength, int
    * \return NX_OK on success, NX_ERROR in the case of an error.   
    * \ingroup c_readwrite
    */
-extern  NXstatus  NXgetattr(NXhandle handle, char* name, void* data, int* iDataLen, int* iType);
+extern  NXstatus  NXgetattr(NXhandle handle, const char* name, void* data, int* iDataLen, int* iType);
 
   /**
    * Get the count of attributes in the currently open dataset, group or global attributes when at root level.
@@ -680,7 +680,7 @@ extern  NXstatus  NXgetnextattra(NXhandle handle, NXname pName, int *rank, int d
    * \return NX_OK on success, NX_ERROR in the case of an error.   
    * \ingroup c_readwrite
    */
-extern  NXstatus  NXgetattra(NXhandle handle, char* name, void* data);
+extern  NXstatus  NXgetattra(NXhandle handle, const char* name, void* data);
 
   /**
    * Get the information about the storage of the named attribute.

--- a/include/napi4.h
+++ b/include/napi4.h
@@ -27,7 +27,7 @@ extern  NXstatus  NX4closedata(NXhandle handle);
   
 extern  NXstatus  NX4getdata(NXhandle handle, void* data);
 extern  NXstatus  NX4getslab64(NXhandle handle, void* data, const int64_t start[], const int64_t size[]);
-extern  NXstatus  NX4getattr(NXhandle handle, char* name, void* data, int* iDataLen, int* iType);
+extern  NXstatus  NX4getattr(NXhandle handle, const char* name, void* data, int* iDataLen, int* iType);
   
 extern  NXstatus  NX4putdata(NXhandle handle, const void* data);
 extern  NXstatus  NX4putslab64(NXhandle handle, const void* data, const int64_t start[], const int64_t size[]);
@@ -48,7 +48,7 @@ extern  NXstatus  NX4printlink(NXhandle handle, NXlink* pLink);
 
 extern  NXstatus  NX4putattra(NXhandle handle, CONSTCHAR* name, const void* data, const int rank, const int dim[], const int iType);
 extern  NXstatus  NX4getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
-extern  NXstatus  NX4getattra(NXhandle handle, char* name, void* data);
+extern  NXstatus  NX4getattra(NXhandle handle, const char* name, void* data);
 extern  NXstatus  NX4getattrainfo(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
 
 void NX4assignFunctions(pNexusFunction fHandle);

--- a/include/napi5.h
+++ b/include/napi5.h
@@ -41,7 +41,7 @@ extern  NXstatus  NX5getnextentry(NXhandle handle, NXname name, NXname nxclass, 
 
 extern  NXstatus  NX5getslab64(NXhandle handle, void* data, const int64_t start[], const int64_t size[]);
 extern  NXstatus  NX5getnextattr(NXhandle handle, NXname pName, int *iLength, int *iType);
-extern  NXstatus  NX5getattr(NXhandle handle, char* name, void* data, int* iDataLen, int* iType);
+extern  NXstatus  NX5getattr(NXhandle handle, const char* name, void* data, int* iDataLen, int* iType);
 extern  NXstatus  NX5getattrinfo(NXhandle handle, int* no_items);
 extern  NXstatus  NX5getgroupID(NXhandle handle, NXlink* pLink);
 extern  NXstatus  NX5getgroupinfo(NXhandle handle, int* no_items, NXname name, NXname nxclass);
@@ -51,7 +51,7 @@ extern  NXstatus  NX5initattrdir(NXhandle handle);
 
 extern  NXstatus  NX5putattra(NXhandle handle, CONSTCHAR* name, const void* data, const int rank, const int dim[], const int iType);
 extern  NXstatus  NX5getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
-extern  NXstatus  NX5getattra(NXhandle handle, char* name, void* data);
+extern  NXstatus  NX5getattra(NXhandle handle, const char* name, void* data);
 extern  NXstatus  NX5getattrainfo(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
 
 void NX5assignFunctions(pNexusFunction fHandle);

--- a/include/napi_internal.h
+++ b/include/napi_internal.h
@@ -63,8 +63,8 @@ extern "C" {
         NXstatus ( *nxgetslab64)(NXhandle handle, void* data, const int64_t start[], const int64_t size[]);
         NXstatus ( *nxgetnextattr)(NXhandle handle, NXname pName, int *iLength, int *iType);
         NXstatus ( *nxgetnextattra)(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
-        NXstatus ( *nxgetattr)(NXhandle handle, char* name, void* data, int* iDataLen, int* iType);
-        NXstatus ( *nxgetattra)(NXhandle handle, char* name, void* data);
+        NXstatus ( *nxgetattr)(NXhandle handle, const char* name, void* data, int* iDataLen, int* iType);
+        NXstatus ( *nxgetattra)(NXhandle handle, const char* name, void* data);
         NXstatus ( *nxgetattrainfo)(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
         NXstatus ( *nxgetattrinfo)(NXhandle handle, int* no_items);
         NXstatus ( *nxgetgroupID)(NXhandle handle, NXlink* pLink);

--- a/include/nxxml.h
+++ b/include/nxxml.h
@@ -54,7 +54,7 @@ NXstatus  NXXgetslab64 (NXhandle fid, void *data,
 				   const int64_t iStart[], const int64_t iSize[]);
 NXstatus  NXXputattr (NXhandle fid, CONSTCHAR *name, const void *data, 
 				   int datalen, int iType);
-NXstatus  NXXgetattr (NXhandle fid, char *name, 
+NXstatus  NXXgetattr (NXhandle fid, const char *name, 
 				   void *data, int* datalen, int* iType);
 
 NXstatus  NXXgetnextentry (NXhandle fid,NXname name, NXname nxclass, int *datatype);
@@ -72,7 +72,7 @@ extern NXstatus  NXXsameID (NXhandle fileid, NXlink* pFirstID, NXlink* pSecondID
 
 extern  NXstatus  NXXputattra(NXhandle handle, CONSTCHAR* name, const void* data, const int rank, const int dim[], const int iType);
 extern  NXstatus  NXXgetnextattra(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
-extern  NXstatus  NXXgetattra(NXhandle handle, char* name, void* data);
+extern  NXstatus  NXXgetattra(NXhandle handle, const char* name, void* data);
 extern  NXstatus  NXXgetattrainfo(NXhandle handle, NXname pName, int *rank, int dim[], int *iType);
 
 void NXXassignFunctions(pNexusFunction fHandle);

--- a/src/napi.c
+++ b/src/napi.c
@@ -1355,7 +1355,7 @@ NXstatus NXgetnextattr(NXhandle fileid, NXname pName, int *iLength, int *iType)
 
   /*-------------------------------------------------------------------------*/
 
-NXstatus NXgetattr(NXhandle fid, char *name, void *data, int *datalen,
+NXstatus NXgetattr(NXhandle fid, const char *name, void *data, int *datalen,
 		   int *iType)
 {
 	pNexusFunction pFunc = handleToNexusFunc(fid);
@@ -1953,7 +1953,7 @@ NXstatus  NXgetnextattra(NXhandle handle, NXname pName, int *rank, int dim[], in
 	pNexusFunction pFunc = handleToNexusFunc(handle);
 	return LOCKED_CALL(pFunc->nxgetnextattra(pFunc->pNexusData, pName, rank, dim, iType));
 }
-NXstatus  NXgetattra(NXhandle handle, char* name, void* data)
+NXstatus  NXgetattra(NXhandle handle, const char* name, void* data)
 {
 	pNexusFunction pFunc = handleToNexusFunc(handle);
 	return LOCKED_CALL(pFunc->nxgetattra(pFunc->pNexusData, name, data));

--- a/src/napi4.c
+++ b/src/napi4.c
@@ -1702,7 +1702,7 @@ static int findNapiClass(pNexusFile pFile, int groupRef, NXname nxclass)
   /*-------------------------------------------------------------------------*/
 
 
-  NXstatus  NX4getattr (NXhandle fid, char *name, void *data, int* datalen, int* iType)
+  NXstatus  NX4getattr (NXhandle fid, const char *name, void *data, int* datalen, int* iType)
   {
     pNexusFile pFile;
     int32 iNew, iType32, count;
@@ -1965,7 +1965,7 @@ NXstatus  NX4getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], i
 }
 
 /*--------------------------------------------------------------------*/
-NXstatus  NX4getattra(NXhandle handle, char* name, void* data)
+NXstatus  NX4getattra(NXhandle handle, const char* name, void* data)
 {
   NXReportError("This is a HDF4 file, attribute array API is not supported here");
   return NX_ERROR;

--- a/src/napi5.c
+++ b/src/napi5.c
@@ -2085,7 +2085,7 @@ NXstatus NX5getnextattr(NXhandle fileid, NXname pName, int *iLength, int *iType)
 
  /*-------------------------------------------------------------------------*/
 
-NXstatus NX5getattr(NXhandle fid, char *name,
+NXstatus NX5getattr(NXhandle fid, const char *name,
 		    void *data, int *datalen, int *iType)
 {
 	pNexusFile5 pFile;
@@ -2480,7 +2480,7 @@ NXstatus  NX5getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], i
 	return NX5getattrainfo(handle, pName, rank, dim, iType);
 }
 /*------------------------------------------------------------------------*/
-NXstatus  NX5getattra(NXhandle handle, char* name, void* data)
+NXstatus  NX5getattra(NXhandle handle, const char* name, void* data)
 {
 	pNexusFile5 pFile;
 	int i, iStart[H5S_MAX_RANK], status, vid;

--- a/src/nxxml.c
+++ b/src/nxxml.c
@@ -1340,7 +1340,7 @@ NXstatus  NXXputattr (NXhandle fid, CONSTCHAR *name, const void *data,
   return NX_OK;
 }
 /*--------------------------------------------------------------------------*/
-NXstatus  NXXgetattr (NXhandle fid, char *name, 
+NXstatus  NXXgetattr (NXhandle fid, const char *name, 
 				   void *data, int* datalen, int* iType){
   pXMLNexus xmlHandle = NULL;
   mxml_node_t *current = NULL;
@@ -1980,7 +1980,7 @@ NXstatus  NXXgetnextattra(NXhandle handle, NXname pName, int *rank, int dim[], i
 }
 
 /*--------------------------------------------------------------------*/
-NXstatus  NXXgetattra(NXhandle handle, char* name, void* data)
+NXstatus  NXXgetattra(NXhandle handle, const char* name, void* data)
 {
   NXReportError("This is an XML file, attribute array API is not supported here");
   return NX_ERROR;


### PR DESCRIPTION
This modifies the argument type of name in `NXgetattr` and `NXgetattra` from `char*` to  `const char*`. In addition to improving const correctness, it fixes warnings like `ISO C++ forbids converting a string constant to ‘char*’ [-Wpedantic]` (GCC 5.3) when calling these functions from C++.