### PR TITLE
Generate export macros in a separate file.

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,68 +1,74 @@
 ## Process this file with cmake
 #==============================================================================
 #  NeXus - Neutron & X-ray Common Data Format
-#  
+#
 #  CMakeLists for building the NeXus library and applications.
 #
 #  Copyright (C) 2011 Stephen Rankin
-#  
+#
 #  This library is free software; you can redistribute it and/or modify it under
 #  the terms of the GNU Lesser General Public License as published by the Free
 #  Software Foundation; either version 2 of the License, or (at your option) any
 #  later version.
-# 
+#
 #  This library is distributed in the hope that it will be useful, but WITHOUT
 #  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 #  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
 #  details.
-# 
+#
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this library; if not, write to the Free Software Foundation, Inc.,
 #  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#             
+#
 #  For further information, see <http://www.nexusformat.org>
 #
 #
 #==============================================================================
 
-add_definitions(-DIN_NEXUS_CPP_LIBRARY=1 ${NX_CPP})
-
+include(GenerateExportHeader)
 #Make NeXus CPP Bindings Static Library
 
 set (HEADERS NeXusFile.hpp NeXusException.hpp NeXusStream.hpp)
-set (SOURCES NeXusFile.hpp NeXusFile.cpp NeXusException.hpp 
+set (SOURCES NeXusFile.hpp NeXusFile.cpp NeXusException.hpp
              NeXusException.cpp NeXusStream.hpp NeXusStream.cpp)
 
 set_property(SOURCE ${SOURCES} APPEND PROPERTY COMPILE_FLAGS ${NX_CFLAGS})
-
-#------------------------------------------------------------------------------
-add_library (NeXus_CPP_Static_Library STATIC ${HEADERS} ${SOURCES})
-set_target_properties(NeXus_CPP_Static_Library PROPERTIES 
-                      OUTPUT_NAME NeXusCPP${STATIC_LIBRARY_SUFFIX})
-
-target_link_libraries(NeXus_CPP_Static_Library NeXus_Static_Library)
 
 #Make NeXus CPP Bindings Shared Library
 #------------------------------------------------------------------------------
 add_library (NeXus_CPP_Shared_Library SHARED ${HEADERS} ${SOURCES})
 target_link_libraries(NeXus_CPP_Shared_Library NeXus_Shared_Library)
+target_include_directories(NeXus_CPP_Shared_Library PUBLIC ${CMAKE_CURRENT_BINARY_DIR} )
 set_target_properties(NeXus_CPP_Shared_Library PROPERTIES
                       OUTPUT_NAME NeXusCPP
                       VERSION "${ABI_VERSION}"
                       SOVERSION ${ABI_CURRENT})
+
+generate_export_header(NeXus_CPP_Shared_Library 
+                       BASE_NAME NEXUS_CPP
+                       EXPORT_FILE_NAME NeXusExport.hpp
+                       EXPORT_MACRO_NAME NXDLL_EXPORT)
+
+#------------------------------------------------------------------------------
+add_library (NeXus_CPP_Static_Library STATIC ${HEADERS} ${SOURCES})
+set_target_properties(NeXus_CPP_Static_Library PROPERTIES
+                      OUTPUT_NAME NeXusCPP${STATIC_LIBRARY_SUFFIX}
+                      COMPILE_FLAGS -DNEXUS_CPP_STATIC_DEFINE)
+target_include_directories(NeXus_CPP_Static_Library PUBLIC ${CMAKE_CURRENT_BINARY_DIR} )
+target_link_libraries(NeXus_CPP_Static_Library NeXus_Static_Library)
+
+
+#------------------------------------------------------------------------------
 
 install (TARGETS NeXus_CPP_Shared_Library
          RUNTIME DESTINATION ${NEXUS_INSTALL_SHLIB} COMPONENT Runtime
          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development)
 
-install (TARGETS NeXus_CPP_Static_Library 
+install (TARGETS NeXus_CPP_Static_Library
          DESTINATION ${CMAKE_INSTALL_LIBDIR}
          COMPONENT Development)
 
-INSTALL (FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nexus  
+INSTALL (FILES ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/NeXusExport.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nexus
          COMPONENT Development)
-
-
-
 

--- a/bindings/cpp/NeXusException.hpp
+++ b/bindings/cpp/NeXusException.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <stdexcept>
+#include "NeXusExport.hpp"
 
 /**
  * \file NeXusException.hpp

--- a/bindings/cpp/NeXusFile.hpp
+++ b/bindings/cpp/NeXusFile.hpp
@@ -6,22 +6,7 @@
 #include <utility>
 #include <vector>
 #include "napi.h"
-
-#ifdef _WIN32
-
-#ifndef _MSC_VER 
-#  define NXDLL_EXPORT
-#else
-#  if IN_NEXUS_CPP_LIBRARY
-#    define NXDLL_EXPORT __declspec(dllexport)
-#  else
-#    define NXDLL_EXPORT __declspec(dllimport)
-#  endif
-#endif /* _MSC_VER */
-
-#else /* _WIN32 */
-#  define NXDLL_EXPORT 
-#endif /* _WIN32 */
+#include "NeXusExport.hpp"
 
 /**
  * \file NeXusFile.hpp Definition of the NeXus C++ API.


### PR DESCRIPTION
Including NeXusException.hpp before NeXusFile.hpp generates a compiler error because `NXDLL_EXPORT` is used before it is defined. The simplest fix is to define this macro in a separate file and include that file in both NeXusException.hpp and NeXusFile.hpp. I didn't bother including it in NeXusStream.hpp since it includes NeXusFile.hpp.

I used CMake's [GenerateExportHeader function](https://cmake.org/cmake/help/v3.5/module/GenerateExportHeader.html) instead of defining the export macros by hand.