### PR TITLE
Fix -Wc++11-narrowing errors.

### DIFF
--- a/bindings/cpp/NeXusFile.cpp
+++ b/bindings/cpp/NeXusFile.cpp
@@ -588,7 +588,7 @@ void File::putAttr(const std::string& name, const std::vector<std::string>& arra
 
   // set rank and dim
   const int rank = 2;
-  int dim[rank] = {array.size(), maxLength};
+  int dim[rank] = {static_cast<int>(array.size()), maxLength};
 
   // write data
   NXstatus status = NXputattra(this->m_file_id, name.c_str(),
@@ -613,7 +613,7 @@ void File::putAttr(const std::string& name, const std::vector<NumT>& array) {
 
   // set rank and dim
   const int rank = 1;
-  int dim[rank] = {array.size()};
+  int dim[rank] = {static_cast<int>(array.size())};
 
   // write data
   NXnumtype type = getType<NumT>();


### PR DESCRIPTION
This fixes two errors that occur when building the C++ bindings with the C++11 or later standard. 

The simplest workaround is to add an explicit cast. If an API change is acceptable, the type of dims should change to match `hsize_t` The default appears to be [unsigned long long](https://www.hdfgroup.org/HDF5/doc/TechNotes/BigDataSmMach.html). 