### PR TITLE
Add suggestions for deprecated functions

### DIFF
--- a/bindings/cpp/NeXusFile.hpp
+++ b/bindings/cpp/NeXusFile.hpp
@@ -116,7 +116,7 @@ namespace NeXus {
      * This is a deprecated function.
      * \param com The compression type.
      */
-    void compress(NXcompression comp) NEXUS_DEPRECATED_FUNCTION;
+    void compress(NXcompression comp) NEXUS_DEPRECATED_FUNCTION();
 
     /**
      * Initialize the pending group search to start again.

--- a/include/napi.h.in
+++ b/include/napi.h.in
@@ -259,9 +259,9 @@ typedef struct {
  */
 
 #if (defined(__GNUC__) || defined(__clang__))
-#define NEXUS_DEPRECATED_FUNCTION __attribute__((deprecated))
+#define NEXUS_DEPRECATED_FUNCTION(msg) __attribute__((deprecated(msg)))
 #else
-#define NEXUS_DEPRECATED_FUNCTION
+#define NEXUS_DEPRECATED_FUNCTION(msg)
 #endif
 
 #ifdef __cplusplus
@@ -435,7 +435,7 @@ extern  NXstatus NXcompmakedata64 (NXhandle handle, CONSTCHAR* label, int dataty
    * \li NX_COMP_HUF Huffmann encoding (only HDF-4)
    * \ingroup c_readwrite
    */
-extern  NXstatus  NXcompress (NXhandle handle, int compr_type) NEXUS_DEPRECATED_FUNCTION;
+extern  NXstatus  NXcompress (NXhandle handle, int compr_type) NEXUS_DEPRECATED_FUNCTION();
 
   /**
    * Open access to a dataset. After this call it is possible to write and read data or 
@@ -632,7 +632,7 @@ extern  NXstatus  NXgetslab64(NXhandle handle, void* data, const int64_t start[]
    * \return NX_OK on success, NX_ERROR in the case of an error, NX_EOD when there are no more items.   
    * \ingroup c_readwrite
    */
-extern  NXstatus  NXgetnextattr(NXhandle handle, NXname pName, int *iLength, int *iType) NEXUS_DEPRECATED_FUNCTION;
+extern  NXstatus  NXgetnextattr(NXhandle handle, NXname pName, int *iLength, int *iType) NEXUS_DEPRECATED_FUNCTION("Use NXgetnextattra instead");
 
   /**
    * Read an attribute containing a single string or numerical value.


### PR DESCRIPTION
The macro is changed to require extra parenthesis. This will help
direct people as to what to do next.

Fixes #438.