### PR TITLE
User unique_ptr to manage heap object rather than stack allocation

### DIFF
--- a/bindings/cpp/NeXusFile.cpp
+++ b/bindings/cpp/NeXusFile.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <typeinfo>
+#include <memory>
 #include "napiconfig.h"
 #include "NeXusFile.hpp"
 #include "NeXusException.hpp"
@@ -1240,7 +1241,8 @@ void File::getAttr(const std::string& name, std::vector<std::string>& array) {
   }
 
   // get attrInfo
-  char attr_name[name.size()+1];
+  char* attr_name = new char[name.size() + 1];
+  std::unique_ptr<char[]> attr_name_deleter(attr_name);
   strcpy(attr_name, name.c_str());
 
   int type;


### PR DESCRIPTION
VS2015 doesn't allow stack objects to be allocated when size is determined at runtime.

See #447 
