### PR TITLE
napi5.c - Free pointer to iname before returning

### DIFF
--- a/src/napi5.c
+++ b/src/napi5.c
@@ -2507,6 +2507,8 @@ NXstatus  NX5getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], i
 			/*
 			   skip NXclass attribute which is internal 
 			 */
+			free(iname);
+			iname = NULL;
 			killAttVID(pFile, vid);
 			return NX5getnextattra(handle, pName, rank, dim, iType);
 		}


### PR DESCRIPTION
The pointer to iname comes from the attr_info() function which calls `strdup`. The resulting pointer is correctly freed outside of the if block checking for internal attributes but is incorrectly handled when we do skip any attributes. 
This PR ensures we free and set the pointer to NULL before returning so we don't leak memory. 

Fixes #449 

It would be nice if this fix could be backported to Ubuntu too if possible as we currently use the prebuilt libraries from there. 