### PR TITLE
Fix and re-enable Java-bindings build with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ add_custom_target(html)
 #-----------------------------------------------------------------------------
 # setup installation directories
 #
-# This is an OS specific task and we need to take care about the target 
-# architecture. 
+# This is an OS specific task and we need to take care about the target
+# architecture.
 #-----------------------------------------------------------------------------
 if(CMAKE_HOST_UNIX)
     #easy on Unix - just follow the GNU standard
@@ -61,7 +61,7 @@ else()
     set(CMAKE_INSTALL_BINDIR bin)
     set(STATIC_LIBRARY_SUFFIX "Static")
     set(NEXUS_INSTALL_SHLIB ${CMAKE_INSTALL_BINDIR})
-endif() 
+endif()
 
 
 #-----------------------------------------------------------------------------
@@ -116,8 +116,6 @@ include(InstallRequiredSystemLibraries)
 include(FindPkgConfig)
 
 #include(cmake_include/FindCBFLib.cmake)
-#include(cmake_include/FindJava.cmake)
-#include(cmake_include/FindJNI.cmake)
 #include(cmake_include/FindGuile.cmake)
 #include(cmake_include/FindMZScheme.cmake)
 #include(cmake_include/FindIDL.cmake)
@@ -170,7 +168,7 @@ if(ENABLE_HDF5)
     else()
         find_package ( HDF5 REQUIRED )
     endif()
-    
+
     find_package(ZLIB)
 
     # Hide annoying and confusing "HDF5_DIR-NOTFOUND" in CMake-GUI
@@ -195,13 +193,13 @@ message(STATUS "Link with: ${NAPI_LINK_LIBS}")
 #------------------------------------------------------------------------------
 if(ENABLE_FORTRAN90 OR ENABLE_FORTRAN77)
     enable_language(Fortran)
-    
+
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall -fbacktrace -pedantic -fcheck=all -Wextra")
     message(STATUS ${CMAKE_Fortran_FLAGS})
 endif()
 
 #-----------------------------------------------------------------------------
-# if contributed programs are built we have to add JPEG as a requirement 
+# if contributed programs are built we have to add JPEG as a requirement
 # for nxextract
 #-----------------------------------------------------------------------------
 if(ENABLE_CONTRIB)
@@ -221,20 +219,12 @@ endif()
 find_package(ZLIB)
 find_package(LibXml2)
 #find_package(LATEX)
-#find_package(PythonInterp)
-
-#Find the java runtime and sdk
-#if(ENABLE_JAVA_BINDINGS)
-#    find_package(Java 1.6)
-#    find_package(JNI)
-#endif()
-
 
 find_library(PTHREAD pthread)
 if(PTHREAD)
    set(PTHREAD_LINK "-lpthread")
 
-   #this fixes an issue on OpenSuse 13.2 where the MXML library is not 
+   #this fixes an issue on OpenSuse 13.2 where the MXML library is not
    #prelinked with threads
    if(WITH_MXML)
        list(APPEND NAPI_LINK_LIBS ${PTHREAD_LINK})
@@ -299,11 +289,11 @@ if(WIN32)
 	    file(GLOB_RECURSE MXML_DLLS "${MXML_LIBRARY_DIRS}/*.dll")
         endif()
 	install(FILES ${HDF4_DLLS} ${HDF5_DLLS} ${MXML_DLLS} DESTINATION bin COMPONENT Runtime)
-	INSTALL(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION bin COMPONENT Runtime) 
+	INSTALL(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION bin COMPONENT Runtime)
 endif()
 
-file(TO_NATIVE_PATH ${PROJECT_SOURCE_DIR} PROJECT_SOURCE_DIR_NATIVE) 
-file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR} PROJECT_BINARY_DIR_NATIVE) 
+file(TO_NATIVE_PATH ${PROJECT_SOURCE_DIR} PROJECT_SOURCE_DIR_NATIVE)
+file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR} PROJECT_BINARY_DIR_NATIVE)
 string(REPLACE "\\" "\\\\" PROJECT_SOURCE_DIR_NATIVE_D ${PROJECT_SOURCE_DIR_NATIVE})
 string(REPLACE "\\" "\\\\" PROJECT_BINARY_DIR_NATIVE_D ${PROJECT_BINARY_DIR_NATIVE})
 
@@ -313,12 +303,12 @@ set (CPACK_GENERATOR TGZ) # not use ZIP on UNIX as problem with symlinks
 set (CPACK_SOURCE_GENERATOR TGZ) # not use ZIP on UNIX as problem with symlinks
 if(WIN32)
     set (CPACK_GENERATOR ${CPACK_GENERATOR};ZIP;NSIS)
-    set (CPACK_SOURCE_GENERATOR ${CPACK_SOURCE_GENERATOR};ZIP) 
+    set (CPACK_SOURCE_GENERATOR ${CPACK_SOURCE_GENERATOR};ZIP)
 elseif(APPLE)
     set (CPACK_GENERATOR ${CPACK_GENERATOR};PackageMaker)
 elseif(CYGWIN)
     set (CPACK_GENERATOR ${CPACK_GENERATOR};CygwinBinary)
-    set (CPACK_SOURCE_GENERATOR ${CPACK_SOURCE_GENERATOR};CygwinSource) 
+    set (CPACK_SOURCE_GENERATOR ${CPACK_SOURCE_GENERATOR};CygwinSource)
 elseif(UNIX)
     set (CPACK_GENERATOR ${CPACK_GENERATOR};DEB;RPM)
 endif()

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,26 +1,26 @@
 ## Process this file with cmake
 #====================================================================
 #  NeXus - Neutron & X-ray Common Data Format
-#  
+#
 #  CMakeLists for building the NeXus library and applications.
 #
 #  Copyright (C) 2011 Stephen Rankin
-#  
+#
 #  This library is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU Lesser General Public
 #  License as published by the Free Software Foundation; either
 #  version 2 of the License, or (at your option) any later version.
-# 
+#
 #  This library is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #  Lesser General Public License for more details.
-# 
+#
 #  You should have received a copy of the GNU Lesser General Public
-#  License along with this library; if not, write to the Free 
-#  Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, 
+#  License along with this library; if not, write to the Free
+#  Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #  MA  02111-1307  USA
-#             
+#
 #  For further information, see <http://www.nexusformat.org>
 #
 #
@@ -44,14 +44,14 @@ if(ENABLE_FORTRAN90)
 endif()
 
 #add_subdirectory (idl)
-#if (NOT(Java_JAVAC_EXECUTABLE MATCHES NOTFOUND))
-#    add_subdirectory (java)
-#endif ()
+if (ENABLE_JAVA)
+    find_package(Java 1.6 COMPONENTS REQUIRED)
+    find_package(JNI REQUIRED)
+
+    add_subdirectory (java)
+endif ()
 #add_subdirectory (matlab)
-#if (PYTHONINTERP_FOUND)
-#    add_subdirectory (python)
-#endif (PYTHONINTERP_FOUND)
 
 if(ENABLE_NXINTER)
-	add_subdirectory (swig)
+    add_subdirectory (swig)
 endif()

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -33,34 +33,33 @@ if(DEFINED Java_JAVAC_EXECUTABLE)
 
         SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-#        MESSAGE(STATUS ${PROJECT_SOURCE_DIR}/bindings/java/)
 
         SET(JAVA_TEST ${PROJECT_SOURCE_DIR}/bindings/java/test/TestJapi.java)
 
-        SET(JAVA_SOURCES ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFException.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFJavaException.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNotImplementedException.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFConstants.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFArray.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNativeData.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NexusException.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NXlink.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NeXusFileInterface.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/AttributeEntry.java 
-             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NexusFile.java 
+        SET(JAVA_SOURCES ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFException.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFJavaException.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNotImplementedException.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFConstants.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFArray.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNativeData.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NexusException.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NXlink.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NeXusFileInterface.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/AttributeEntry.java
+             ${PROJECT_SOURCE_DIR}/bindings/java/org/nexusformat/NexusFile.java
              ${JAVA_TEST})
 
-         SET(JAVA_CLASSES ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFException.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFJavaException.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNotImplementedException.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFConstants.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFArray.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNativeData.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NexusException.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NXlink.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NeXusFileInterface.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/AttributeEntry.class 
-             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NexusFile.class 
+         SET(JAVA_CLASSES ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFException.class
+             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFJavaException.class
+             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNotImplementedException.class
+             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFConstants.class
+             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFArray.class
+             ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/HDFNativeData.class
+             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NexusException.class
+             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NXlink.class
+             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NeXusFileInterface.class
+             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/AttributeEntry.class
+             ${PROJECT_BINARY_DIR}/bindings/java/org/nexusformat/NexusFile.class
              ${PROJECT_BINARY_DIR}/bindings/java/TestJapi.class)
 
         SET(EXTRA_CLASSES ${PROJECT_BINARY_DIR}/bindings/java/ncsa/hdf/hdflib/ArrayDescriptor.class)
@@ -73,21 +72,31 @@ if(DEFINED Java_JAVAC_EXECUTABLE)
 
         STRING(REPLACE ".java" ".class" javaclass "${JAVA_SOURCES}")
 
-        ADD_CUSTOM_COMMAND( 
-            OUTPUT    ${JAVA_CLASSES}
+        # The javah tool was superseded by functionality added to javac in JDK8
+        # Provide backwards compatability if we have an older version of Java
+        if(Java_JAVAH_EXECUTABLE)
+          set(JAVAC_EXTRA_ARGS)
+          set(JAVAC_EXTRA_OUTPUT)
+        else()
+          set(JAVAC_EXTRA_ARGS "-h" ".")
+          set(JAVAC_EXTRA_OUTPUT ${JNI_HEADER})
+        endif()
+
+        ADD_CUSTOM_COMMAND(
+            OUTPUT    ${JAVA_CLASSES} ${JAVAC_EXTRA_OUTPUT}
             COMMAND   ${Java_JAVAC_EXECUTABLE}
-            ARGS      -d . ${JAVA_SOURCES}
+            ARGS      -d . ${JAVAC_EXTRA_ARGS} ${JAVA_SOURCES}
             COMMENT   "Compile Java"
         )
 
-        ADD_CUSTOM_COMMAND( 
+        ADD_CUSTOM_COMMAND(
             OUTPUT    ${EXTRA_CLASSES}
-            COMMAND   
+            COMMAND
             DEPENDS   ${JAVA_CLASSES}
             COMMENT   "Include Extra Built Classes"
         )
 
-        ADD_CUSTOM_COMMAND( 
+        ADD_CUSTOM_COMMAND(
             OUTPUT    ${JAR_ARCHIVE}
             COMMAND   ${Java_JAR_EXECUTABLE}
             ARGS      cvf ${JAR_ARCHIVE} ${JAVA_CLASSES} ${EXTRA_CLASSES}
@@ -95,18 +104,20 @@ if(DEFINED Java_JAVAC_EXECUTABLE)
             COMMENT   "Build JAR File"
         )
 
-        ADD_CUSTOM_COMMAND( 
-            OUTPUT    ${JNI_HEADER}
-            COMMAND   ${Java_JAVAH_EXECUTABLE}
-            ARGS      -jni -d native -classpath . org.nexusformat.NexusFile
-            DEPENDS   ${JAR_ARCHIVE}
-            COMMENT   "Build JNI Header"
-        )
+        if(Java_JAVAH_EXECUTABLE)
+            ADD_CUSTOM_COMMAND(
+                OUTPUT    ${JNI_HEADER}
+                COMMAND   ${Java_JAVAH_EXECUTABLE}
+                ARGS      -jni -d native -classpath . org.nexusformat.NexusFile
+                DEPENDS   ${JAR_ARCHIVE}
+                COMMENT   "Build JNI Header"
+          )
+        endif()
 
-        ADD_CUSTOM_COMMAND( 
+        ADD_CUSTOM_COMMAND(
             OUTPUT    ${JAVA_DOCS}
             COMMAND   ${Java_JAVADOC_EXECUTABLE}
-            ARGS      -d ${JAVA_DOCS} -windowtitle jnexus -doctitle jnexus -classpath . 
+            ARGS      -d ${JAVA_DOCS} -windowtitle jnexus -doctitle jnexus -classpath .
                       -sourcepath ${PROJECT_SOURCE_DIR}/bindings/java org.nexusformat ncsa.hdf.hdflib
             DEPENDS   ${JNI_HEADER}
             COMMENT   "Build Javadocs"
@@ -115,15 +126,15 @@ if(DEFINED Java_JAVAC_EXECUTABLE)
         ADD_CUSTOM_TARGET(NexusJavaBuild ALL echo
            DEPENDS   ${JAR_ARCHIVE}
         )
-        
+
         ADD_CUSTOM_TARGET(NexusJavadocBuild ALL echo
            DEPENDS   ${JAVA_DOCS}
         )
 
-        ADD_LIBRARY(jnexus SHARED native/hdfnativeImp.c 
-                     native/hdfexceptionImp.c 
-                     native/handle.c 
-                     native/NexusFile.c 
+        ADD_LIBRARY(jnexus SHARED native/hdfnativeImp.c
+                     native/hdfexceptionImp.c
+                     native/handle.c
+                     native/NexusFile.c
                      native/hdfexceptionImp.h)
 
 		if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -134,7 +145,7 @@ if(DEFINED Java_JAVAC_EXECUTABLE)
                       VERSION 1.0 SOVERSION 4)
 		endif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
-        TARGET_LINK_LIBRARIES(jnexus NeXus_Shared_Library 
+        TARGET_LINK_LIBRARIES(jnexus NeXus_Shared_Library
                       ${READLINE_LINK} ${M_LINK} ${DF_LINK}
                       ${DL_LINK} ${PTHREAD_LINK} ${TERMCAP_LINK} ${HDF4_LINK}
                       ${HISTORY_LINK} ${JPEG_LIBRARIES} ${ZIP_LIB} ${SZIP_LIB}
@@ -142,19 +153,17 @@ if(DEFINED Java_JAVAC_EXECUTABLE)
 
         INSTALL(TARGETS jnexus
             RUNTIME DESTINATION bin COMPONENT Runtime
-			LIBRARY DESTINATION lib COMPONENT Runtime 
+			LIBRARY DESTINATION lib COMPONENT Runtime
 			ARCHIVE DESTINATION lib COMPONENT Runtime
         )
 
         INSTALL(FILES ${JAR_ARCHIVE} DESTINATION share/java COMPONENT Runtime)
 
         INSTALL(DIRECTORY ${JAVA_DOCS} DESTINATION ${NXDOCDIR}/java COMPONENT Documentation)
-		
+
 		install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/COPYING.NCSA ${CMAKE_CURRENT_SOURCE_DIR}/README.JNEXUS DESTINATION ${NXDOCDIR}/java COMPONENT Documentation)
 
         INSTALL(FILES ${JAVA_TEST} DESTINATION ${NXEXAMPLEDIR}/ COMPONENT Examples)
 
      endif(DEFINED JNI_INCLUDE_DIRS)
 endif(DEFINED Java_JAVAC_EXECUTABLE)
-
-


### PR DESCRIPTION
This brings the CMake configuration for the Java bindings back to life. I've tested that it builds on both Debian stable and testing.

It looks like emacs has also "fixed" some whitespace issues in the files - I hope that is okay.