### PR TITLE
Do not throw exception from File destructor

### DIFF
--- a/bindings/cpp/NeXusFile.cpp
+++ b/bindings/cpp/NeXusFile.cpp
@@ -194,7 +194,9 @@ File::~File() {
     NXstatus status = NXclose(&(this->m_file_id));
     this->m_file_id = NULL;
     if (status != NX_OK) {
-      throw Exception("NXclose failed", status);
+      stringstream msg;
+      msg << "NXclose failed with status: " << status << "\n";
+      NXReportError(const_cast<char*>(msg.str().c_str()));
     }
   }
 }


### PR DESCRIPTION
gcc was warning that it is discouraged to throw from destructors. This removes the exception and instead uses the standard `NXReportError` function.