### PR TITLE
Insert relevant package dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,8 @@ elseif(CYGWIN)
     set (CPACK_SOURCE_GENERATOR ${CPACK_SOURCE_GENERATOR};CygwinSource) 
 elseif(UNIX)
     set (CPACK_GENERATOR ${CPACK_GENERATOR};DEB;RPM)
+    set (CPACK_DEBIAN_PACKAGE_DEPENDS "libhdf5-103, libhdf5-dev")
+    set (CPACK_RPM_PACKAGE_REQUIRES "hdf5, hdf5-devel")
 endif()
 # Include of CPack must always be last
 include(CPack)


### PR DESCRIPTION
When running with DEB or RPM generators, the shown CPACK variables can be used to generate correct dependencies.

Ideally this should of course be enriched to include e.g. HDF4 and xml dependencies if these are requested.

- Or are you guys in fact using a completely different approach already to set the dependencies?