### PR TITLE
Fixed memory leak caused by allocation inside NXIformatNeXusTime.

### DIFF
--- a/src/napi5.c
+++ b/src/napi5.c
@@ -440,8 +440,10 @@ NXstatus NX5open(CONSTCHAR * filename, NXaccess am, NXhandle * pHandle)
                 H5Gclose(root_id);
                 H5Fclose(pNew->iFID);
                 free(pNew);
+                free(time_buffer);
                 return NX_ERROR;
             }
+            free(time_buffer);
         }
 
         /*finally we set the NXroot NX_class attribute*/


### PR DESCRIPTION
Free time_buffer in napi5.c which is allocated inside NXIformatNeXusTime.